### PR TITLE
correção na remoção

### DIFF
--- a/tentativa.c
+++ b/tentativa.c
@@ -288,7 +288,7 @@ TABM* remover(TABM* arv, int ch, int t){
 		}
 	}
 	printf("\nExecutando uma chamada recursiva no filho %d.\n", i);
-	arv->filho[i] = remover(arv->filho[i], ch, t);
+	arv->filho[i+1] = remover(arv->filho[i+1], ch, t);
 	return arv;
 }
 


### PR DESCRIPTION
ao remover um registro igual ao imdice do nó pai, removia o registro anterior ao especificado